### PR TITLE
Fixed deprecated warnings

### DIFF
--- a/src/HttpClient/ClientInterface.php
+++ b/src/HttpClient/ClientInterface.php
@@ -4,5 +4,5 @@ namespace ThemeXpert\Paddle\HttpClient;
 
 interface ClientInterface
 {
-    public static function sendHttpRequest(string $url, string $method, array $bodyData = null, array $config = array()): string;
+    public static function sendHttpRequest(string $url, string $method, ?array $bodyData = null, array $config = array()): string;
 }

--- a/src/HttpClient/CurlClient.php
+++ b/src/HttpClient/CurlClient.php
@@ -6,7 +6,7 @@ use ThemeXpert\Paddle\Util\Util;
 
 class CurlClient implements ClientInterface
 {
-    public static function sendHttpRequest(string $url, string $method, array $bodyData = null, array $config = array()): string
+    public static function sendHttpRequest(string $url, string $method, ?array $bodyData = null, array $config = array()): string
     {
         // Check if cURL is not enabled
         // TODO: Add Exception

--- a/src/Paddle.php
+++ b/src/Paddle.php
@@ -62,7 +62,7 @@ final class Paddle
      *
      * @access public
      */
-    public function __construct(string $vendorId = null, string $authCode = null, string $publicKey = null)
+    public function __construct(?string $vendorId = null, ?string $authCode = null, ?string $publicKey = null)
     {
 
         if ($vendorId && $authCode) {
@@ -70,11 +70,11 @@ final class Paddle
         }
     }
 
-    public static function setApiCredentials(string $vendorId, string $authCode, string $publicKey = null): bool
+    public static function setApiCredentials(string $vendorId, string $authCode, ?string $publicKey = null): bool
     {
-        self::$vendorId   = (int) trim($vendorId)   ?? null;
-        self::$authCode   = trim($authCode)         ?? null;
-        self::$publicKey  = trim($publicKey)        ?? null;
+        self::$vendorId  = !empty($vendorId) ? (int) trim($vendorId) : null;
+        self::$authCode  = !empty($authCode) ? trim($authCode) : null;
+        self::$publicKey = !empty($publicKey) ? trim($publicKey) : null;
 
         return true;
     }

--- a/src/Paddle/Checkout/Price.php
+++ b/src/Paddle/Checkout/Price.php
@@ -9,7 +9,7 @@ class Price extends ApiResource
 {
     const CLASS_URL = 'prices';
 
-    public static function get(array $productIds, array $coupons, string $customerCountry = null, string $customerIp = null): string
+    public static function get(array $productIds, array $coupons, ?string $customerCountry = null, ?string $customerIp = null): string
     {
         if (empty($customerCountry) && empty($customerIp)) {
             // TODO:: Add Exception

--- a/src/Paddle/Product/Transaction.php
+++ b/src/Paddle/Product/Transaction.php
@@ -17,7 +17,7 @@ class Transaction extends ApiResource
         self::$credentials = Paddle::getApiCredentials();
     }
 
-    public static function list(string $entity, int $id, int $page = null): string
+    public static function list(string $entity, int $id, ?int $page = null): string
     {
         // TODO:: Verify $entity as only  User ID, Subscription ID, Order ID, Checkout ID (hash) or Product ID
         self::init();

--- a/src/Paddle/Subscription/Plan.php
+++ b/src/Paddle/Subscription/Plan.php
@@ -28,7 +28,7 @@ class Plan extends ApiResource
         return CurlClient::sendHttpRequest($url, 'POST', $bodyData);
     }
 
-    public static function list(int $plan = null): string
+    public static function list(?int $plan = null): string
     {
         self::init();
 

--- a/src/Paddle/Verify.php
+++ b/src/Paddle/Verify.php
@@ -10,7 +10,7 @@ class Verify extends ApiResource
      */
     private static $publicKey;
 
-    public function __construct(string $publicKey = null)
+    public function __construct(?string $publicKey = null)
     {
         if ($publicKey) {
             self::setApiPublicKey($publicKey);
@@ -37,7 +37,7 @@ class Verify extends ApiResource
         return self::$publicKey;
     }
 
-    public static function webHookSignature(string $signature, array $webHookData, string $publicKey = null): array
+    public static function webHookSignature(string $signature, array $webHookData, ?string $publicKey = null): array
     {
         if (!empty($publicKey)) {
             self::setApiPublicKey($publicKey);

--- a/src/Util/Url.php
+++ b/src/Util/Url.php
@@ -5,9 +5,9 @@ use ThemeXpert\Paddle\Paddle;
 
 class Url
 {
-    public static function getUrl($base, $version = '2.0', $path)
+    public static function getUrl($base, $version, $path)
     {
-        return "{$base}/api/{$version}/${path}";
+        return "{$base}/api/{$version}/{$path}";
     }
 
     public static function checkoutUrl($path, $version = '2.0')


### PR DESCRIPTION
# Issue
Closes #1 

# Summary
This pull request introduces changes to improve type safety and consistency across the codebase by using nullable types (`?type`) where appropriate. Additionally, a minor bug fix was made to correct a string interpolation issue in `src/Util/Url.php`.

### Type Safety and Consistency Improvements:
* `src/HttpClient/ClientInterface.php` and `src/HttpClient/CurlClient.php`: Updated the `sendHttpRequest` method to use `?array` for the `$bodyData` parameter, ensuring it can explicitly accept `null` values. [[1]](diffhunk://#diff-0b411177fbbca6075aed402433aa7fdbee1049d82d4ca82651784d8dfa14ab8dL7-R7) [[2]](diffhunk://#diff-cf58b0f90887d5b4301b1e47e12c8202efe7d0e9c1d924cffb6b41e0e01d38e6L9-R9)
* [`src/Paddle.php`](diffhunk://#diff-8c6a4e120a6784cc0f30d9c287536812c367e80312e8326013681d7fabeae680L65-R77): Updated the constructor and `setApiCredentials` method to use nullable types (`?string`) for parameters, improving clarity and handling of optional inputs. Adjusted logic to avoid unnecessary null coalescing.
* [`src/Paddle/Checkout/Price.php`](diffhunk://#diff-d6d308ad3497ba83a5368ea0f5c0ae2e037cc68f3b85aec6710a45b71a071342L12-R12): Modified the `get` method to use nullable types (`?string`) for `$customerCountry` and `$customerIp` parameters.
* `src/Paddle/Product/Transaction.php` and `src/Paddle/Subscription/Plan.php`: Updated the `list` methods to use nullable types (`?int`) for optional parameters like `$page` and `$plan`. [[1]](diffhunk://#diff-5b5bcb5ca7a9c7f4dc9e7a83e49e313d72295e4e6ff06d4672e6875cbb76e289L20-R20) [[2]](diffhunk://#diff-37f3ca84ba0d9cdfb2983833ca15c2922a58d079615a2442973d8d4a8fc9edbaL31-R31)
* [`src/Paddle/Verify.php`](diffhunk://#diff-4180ed7c322445171757d43cd611a8e01f392fb3345874770b00a3a02f12d637L13-R13): Updated the constructor and `webHookSignature` method to use nullable types (`?string`) for the `$publicKey` parameter. [[1]](diffhunk://#diff-4180ed7c322445171757d43cd611a8e01f392fb3345874770b00a3a02f12d637L13-R13) [[2]](diffhunk://#diff-4180ed7c322445171757d43cd611a8e01f392fb3345874770b00a3a02f12d637L40-R40)

### Bug Fix:
* [`src/Util/Url.php`](diffhunk://#diff-e63496ebc0f8f0852af79d51c6da3bf91ffd22dc598c0cc41bd78fc790e5c3ebL8-R10): Fixed a string interpolation issue in the `getUrl` method by replacing `${path}` with `{$path}` for proper variable resolution. Removed the default value for the `$version` parameter to simplify the method signature.